### PR TITLE
Passthrough all error fields in NetworkQueryer

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,15 +2,11 @@ package graphql
 
 import "strings"
 
-// ErrorExtensions define fields that extend the standard graphql error shape
-type ErrorExtensions struct {
-	Code 		string `json:"code"`
-}
-
 // Error represents a graphql error
 type Error struct {
-	Extensions ErrorExtensions 	`json:"extensions"`
-	Message    string          	`json:"message"`
+	Extensions map[string]interface{} `json:"extensions"`
+	Message    string                 `json:"message"`
+	Path       []interface{}          `json:"path,omitempty"`
 }
 
 func (e *Error) Error() string {
@@ -21,8 +17,8 @@ func (e *Error) Error() string {
 func NewError(code string, message string) *Error {
 	return &Error{
 		Message: message,
-		Extensions: ErrorExtensions{
-			Code: code,
+		Extensions: map[string]interface{}{
+			"code": code,
 		},
 	}
 }

--- a/queryer.go
+++ b/queryer.go
@@ -175,14 +175,21 @@ func (q *NetworkQueryer) ExtractErrors(result map[string]interface{}) error {
 				return errors.New("error message was not a string")
 			}
 
-			code := ""
-			extensions, ok := obj["extensions"].(map[string]interface{})
-			if ok {
-				code = extensions["code"].(string)
+			var extensions map[string]interface{}
+			if e, ok := obj["extensions"].(map[string]interface{}); ok {
+				extensions = e
 			}
 
+			var path []interface{}
+			if p, ok := obj["path"].([]interface{}); ok {
+				path = p
+			}
 
-			errList = append(errList, NewError(code, message))
+			errList = append(errList, &Error{
+				Message:    message,
+				Path:       path,
+				Extensions: extensions,
+			})
 		}
 
 		return errList


### PR DESCRIPTION
Allows all error details from the remote service to be passed through the NetworkQueryer.

The main change is letting the `extensions` field be a map, rather than a struct, as the extensions are application specific and cannot be known ahead of time by the nexus server.

Also added the `path` field to errors.

We are notably still lacking the `location` field, but I'm not sure how to solve for that yet, given the way nexus runs only portions of the query against a single node.